### PR TITLE
bug(buffer): Clean filePaths

### DIFF
--- a/example/gulpfile.js
+++ b/example/gulpfile.js
@@ -39,3 +39,5 @@ gulp.task('test-path', function() {
 gulp.task('dev', function() {
     gulp.watch('./*.js', ['test-integration']);
 });
+
+gulp.task('multiple', ['default', 'test-integration']);

--- a/example/specs/integration/integration.js
+++ b/example/specs/integration/integration.js
@@ -1,4 +1,4 @@
-describe('integration', function() {
+describe('Integration tests', function() {
   it('should pass integration test', function() {
     expect(1 + 2).toEqual(3);
   });

--- a/example/specs/unit/fixture.js
+++ b/example/specs/unit/fixture.js
@@ -1,4 +1,4 @@
-describe('fixture', function () {
+describe('Unit tests', function () {
 	it('should pass', function () {
 		expect(1 + 2).toEqual(3);
 	});

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var path = require('path'),
     handlebar = require('handlebars'),
     fs = require('fs'),
     execFile = require('child_process').execFile,
-    filePaths = [],
     jasmineCss = path.join(__dirname, '/vendor/jasmine-2.0/jasmine.css'),
     jasmineJs = [
       path.join(__dirname, '/vendor/jasmine-2.0/jasmine.js'),
@@ -91,7 +90,7 @@ module.exports = function (options) {
 
     // Reference to the file paths piped in
     gutil.log('Running Jasmine with PhantomJS');
-    
+    var filePaths = []; 
     return through.obj(
       function (file, encoding, callback) {
         
@@ -117,6 +116,7 @@ module.exports = function (options) {
       terminalReporter = require('./lib/terminal-reporter.js').TerminalReporter;
 
   gutil.log('Running Jasmine with minijasminenode2');
+  var filePaths = [];
   return through.obj(
       function(file, encoding, callback) {
         if (file.isNull()) {


### PR DESCRIPTION
Forces re-instantiation of the filePaths array for each instance run.
Fixes bug with multiple instances running jasmine-phantom.
