### PR TITLE
feat(specHtml): allow custom html runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ Default: false
 Keep the `specRunner.html` file after build. If given a string, it will keep
 the runner at the string path.
 
+#### specHtml
+Type: `string`
+Default: null
+
+**Only use in combination with `integration: true`**
+
+Allows you to specify the Html runner that Jasmine uses **only** during
+integration tests.
+
 #### vendor
 Type: `string|array`
 Default: null

--- a/example/gulpfile.js
+++ b/example/gulpfile.js
@@ -47,6 +47,15 @@ gulp.task('test-vendor', function() {
     }));
 });
 
+
+gulp.task('test-runner', function() {
+  return gulp.src('specs/integration/require-integration.js')
+    .pipe(jasmine({
+      integration: true,
+      specHtml: 'specRunner.html'
+    }));
+});
+
 //Watch task
 gulp.task('dev', function() {
     gulp.watch('specs/unit/*.js', ['test-vendor']);


### PR DESCRIPTION
Adds option for users to run their own Html runners in integration tests.
