### PR TITLE
Fix abort on fail ignoring failures when there’s just one spec

### DIFF
--- a/example/gulpfile.js
+++ b/example/gulpfile.js
@@ -19,12 +19,13 @@ gulp.task('test-unit-path', function() {
     }));
 });
 
+// Throw a gulp error when tests fail
 gulp.task('test-integration-abort', function() {
   return gulp.src('specs/unit/**.js')
     .pipe(jasmine({
       keepRunner: './',
       integration: true,
-      abortOnTestFailure: true
+      abortOnFail: true
     }));
 });
 

--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ function compileRunner(options) {
         var childArgs = [
           path.join(__dirname, '/lib/jasmine-runner.js'),
           specHtml,
-          gulpOptions.abortOnTestFailure
+          gulpOptions.abortOnFail
         ];
         runPhantom(childArgs, onComplete);
       } else {

--- a/lib/jasmine-runner.js
+++ b/lib/jasmine-runner.js
@@ -11,7 +11,6 @@ if (system.args.length < 2 ) {
 }
 
 if(system.args.length === 3 && system.args[2] !== 'undefined') {
-  console.log(system.args[2]);
   abortOnFail = system.args[2];
 }
 

--- a/lib/jasmine-runner.js
+++ b/lib/jasmine-runner.js
@@ -2,7 +2,7 @@ var system = require('system'),
     abortOnFail = false,
     hasTestFailures = false,
     page = require('webpage').create(),
-    errorRegEx = /^\d+ specs.*failure/,
+    errorRegEx = /^\d+ spec.*failure/,
     finishRegEx = /^Finished in \d*\.\d* second/;
 
 if (system.args.length < 2 ) {


### PR DESCRIPTION
The fix is 27d5d5f, other commits just clean up a couple of things left over from the previous version of the flag.

Feel free to cherry pick some of them or merge them all. Thanks for the great plugin!