### PR TITLE
bug: fixes #28

### DIFF
--- a/example/gulpfile.js
+++ b/example/gulpfile.js
@@ -75,6 +75,15 @@ gulp.task('test-runner', function() {
     }));
 });
 
+gulp.task('test-runner-abort', function() {
+  return gulp.src('specs/integration/require-integration.js')
+    .pipe(jasmine({
+      integration: true,
+      specHtml: 'specRunner.html',
+      abortOnFail: true
+    }));
+});
+
 //Watch task
 gulp.task('dev', function() {
     gulp.watch('specs/unit/*.js', ['test-vendor']);

--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ function runPhantom(childArguments, onComplete) {
       }
 
       if(gulpOptions.specHtml === undefined && (gulpOptions.keepRunner === undefined || gulpOptions.keepRunner === false)) {
+        console.log('OMGOMGOMGOMG')
         cleanup(childArguments[1]);
       }
 
@@ -112,7 +113,7 @@ function compileRunner(options) {
         var childArgs = [
           path.join(__dirname, '/lib/jasmine-runner.js'),
           specHtml,
-          gulpOptions.abortOnFail
+          JSON.stringify(gulpOptions)
         ];
         runPhantom(childArgs, onComplete);
       } else {
@@ -148,8 +149,12 @@ module.exports = function (options) {
         try {
           if(gulpOptions.specHtml) {
             runPhantom(
-              [path.join(__dirname, '/lib/jasmine-runner.js'), path.resolve(gulpOptions.specHtml)], function() {
-              callback(null);
+              [
+                path.join(__dirname, '/lib/jasmine-runner.js'),
+                path.resolve(gulpOptions.specHtml),
+                JSON.stringify(gulpOptions)
+              ], function(success) {
+              callback(success);
             });
           } else {
             compileRunner({

--- a/lib/jasmine-runner.js
+++ b/lib/jasmine-runner.js
@@ -10,8 +10,10 @@ if (system.args.length < 2 ) {
     phantom.exit(1);
 }
 
-if(system.args.length === 3 && system.args[2] !== 'undefined') {
-  abortOnFail = system.args[2];
+if(system.args.length === 3 &&
+    system.args[2] !== 'undefined') {
+
+  abortOnFail = JSON.parse(system.args[2]).abortOnFail;
 }
 
 // Route "console.log()" calls from within the Page context to the main Phantom context (i.e. current "this")


### PR DESCRIPTION
Passes Gulp options through to the jasmine runner instead of depending on the abortFail.
Better future proofing.
Fixes #28, alternative solution to #29.