### PR TITLE
Remove a debugging log in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,6 @@ function runPhantom(childArguments, onComplete) {
       }
 
       if(gulpOptions.specHtml === undefined && (gulpOptions.keepRunner === undefined || gulpOptions.keepRunner === false)) {
-        console.log('OMGOMGOMGOMG')
         cleanup(childArguments[1]);
       }
 


### PR DESCRIPTION
Not a very painful thing, but there's a debugging log that's been left in index.js... gulp's output would definitely look better without it !