### PR TITLE
Allow import of vendor scripts from another domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Default: null
 
 **Only use in combination with `integration: true`**
 
-Allows you to specify the Html runner that Jasmine uses **only** during
+Allows you to specify the HTML runner that Jasmine uses **only** during
 integration tests.
 
 #### vendor
@@ -114,11 +114,12 @@ Default: null
 
 **Only use in combination with `integration: true`**
 
-This option allows you to pass in a glob (i.e.: `**/*.js`) that will include
-any vendor files that need to be present for your specs to run (like jQuery for
-example).
+A list of vendor scripts to import into the HTML runner, either as file 
+globs (e.g. `"**/*.js"`) or fully-qualified URLs (e.g. 
+`"http://my.cdn.com/jquery.js"`).
 
-You can also pass in an array of glob strings (i.e.: `["test/*.js", "vendor/jquery.js"]`).
+This option accepts either a single string or an array of strings (e.g. 
+`["test/*.js", "http://my.cdn.com/underscore.js"]`).
 
 Technologies Used
 -----------------

--- a/index.js
+++ b/index.js
@@ -78,18 +78,23 @@ function compileRunner(options) {
   fs.readFile(path.join(__dirname, '/lib/specRunner.handlebars'), 'utf8', function(error, data) {
     if (error) throw error;
 
-    if(gulpOptions.vendor) {
-      if(typeof gulpOptions.vendor === 'string') {
-        glob.sync(gulpOptions.vendor).forEach(function(newFile) {
-            vendorJs.push(path.join(process.cwd(), newFile));
-        });
-      } else if (Array.isArray(gulpOptions.vendor)) {
-        gulpOptions.vendor.forEach(function(fileGlob) {
+    var vendorScripts = gulpOptions.vendor;
+
+    if (vendorScripts) {
+      if (typeof vendorScripts === 'string') {
+        vendorScripts = [vendorScripts];
+      }
+
+      vendorScripts.forEach(function(fileGlob) {
+        if (fileGlob.match(/^http/)) {
+          vendorJs.push(fileGlob);
+        }
+        else {
           glob.sync(fileGlob).forEach(function(newFile) {
             vendorJs.push(path.join(process.cwd(), newFile));
           });
-        });
-      }
+        }
+      });
     }
     // Create the compile version of the specRunner from Handlebars
     var specData = handlebar.compile(data),


### PR DESCRIPTION
Hi, this small change allows you to include vendor scripts which may reside at another domain (for example, a CDN). API is the same—vendor option still accepts a string or array, e.g.

```
vendor: [
  './my/scripts/jquery.js',
  'http://somecdn.com/some/script.js'
]
```

Note I did not update the README file.

Thanks,
Adam

