### PR TITLE
Install phantomJs as a dependency and run test with this phantomJs

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,10 @@ var path = require('path'),
     requireUncached = require('require-uncached');
 
 
+/**
+* @hgarcia
+* Took from karma-phantomjs-launcher
+**/
 var phantomJSExePath = function () {
   // If the path we're given by phantomjs is to a .cmd, it is pointing to a global copy.
   // Using the cmd as the process to execute causes problems cleaning up the processes

--- a/index.js
+++ b/index.js
@@ -8,6 +8,21 @@ var path = require('path'),
     execFile = require('child_process').execFile,
     requireUncached = require('require-uncached');
 
+
+var phantomJSExePath = function () {
+  // If the path we're given by phantomjs is to a .cmd, it is pointing to a global copy.
+  // Using the cmd as the process to execute causes problems cleaning up the processes
+  // so we walk from the cmd to the phantomjs.exe and use that instead.
+
+  var phantomSource = require('phantomjs').path;
+
+  if (path.extname(phantomSource).toLowerCase() === '.cmd') {
+    return path.join(path.dirname( phantomSource ), '//node_modules//phantomjs//lib//phantom//phantomjs.exe');
+  }
+
+  return phantomSource;
+};
+
 /*
  * Global variables
  *
@@ -38,12 +53,13 @@ function cleanup(path) {
 
 /**
   * Executes Phantom with the specified arguments
-  * 
+  *
   * childArguments: Array of options to pass Phantom
   * [jasmine-runner.js, specRunner.html]
   **/
 function runPhantom(childArguments, onComplete) {
-    execFile('phantomjs', childArguments, function(error, stdout, stderr) {
+    var phantom = phantomJSExePath();
+    execFile(phantom, childArguments, function(error, stdout, stderr) {
       var success = null;
 
       if(error !== null) {
@@ -198,7 +214,7 @@ module.exports = function (options) {
       miniJasmineLib.addSpecs(file.path);
       filePaths.push(file.path);
       callback(null, file);
-    }, 
+    },
     function(callback) {
       var stream = this;
       gutil.log('Running Jasmine with minijasminenode2');

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "through2": "^0.6.1",
     "handlebars": "^2.0.0",
     "require-uncached": "^1.0.2",
-    "glob": "^4.0.6"
+    "glob": "^4.0.6",
+    "phantomjs": "~1.9"
   },
   "devDependencies": {
     "JSON": "^1.0.0",


### PR DESCRIPTION
Avoids the need of a global phantomJs.
Simplifies the deployment and build process in your CI.
We are building an array of services and applications and we need them to be self contained, this allow us to just do clone, npm install npm test and npm start without the need or anything installed globally.
The code was taken from the karma-phantomjs-launcher that uses a local phantomJs as well.
Cheers.