### PR TITLE
Lazy require minijasminenode2 if using PhantomJS

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,7 +174,6 @@ function compileRunner(options) {
 
 module.exports = function (options) {
   var filePaths = [],
-      miniJasmineLib = requireUncached('minijasminenode2'),
       terminalReporter = require('./lib/terminal-reporter.js').TerminalReporter;
 
   gulpOptions = options || {};
@@ -221,6 +220,7 @@ module.exports = function (options) {
     );
   }
 
+  var miniJasmineLib = requireUncached('minijasminenode2');
   return through.obj(
     function(file, encoding, callback) {
       if (file.isNull()) {


### PR DESCRIPTION
```
Node: 0.12.7
NPM:  3.5.2
```

We're running into an issue with `minijasminenode2` where it makes an [assumption](https://github.com/juliemr/minijasminenode/blob/jasmine2/lib/index.js#L5) on the location of `node_modules` directory. With npm 3.0.0 and above, [all dependencies and their dependencies are installed flat](https://github.com/npm/npm/blob/master/CHANGELOG.md#flat-flat-flat) and no longer nested.

While this isn't really an issue with this project itself, we are running into an issue where we have configured `gulp-jasmine-phantom` to run via PhantomJS (`integration: true`), but due to the Jasmine require, it throws an exception and is unable to execute our test suite.

This does not solve the issue for users that want to use npm 3.0.0+ and run tests through `minijasminenode2`, but this will help other users (like ourselves) to run tests through PhantomJS.

Please consider this pull request, thanks.