### PR TITLE
3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ Default: false
 
 Allows you to run the unit tests in a semi-random order. The random seed will be printed out after the tests have completed to allow for easier debugging.
 
+#### seed (unit tests only)
+Type: 'number'<br />
+
+Provides a given seed to Jasmine to run the tests in.
+
 Technologies Used
 -----------------
 

--- a/README.md
+++ b/README.md
@@ -81,12 +81,6 @@ gulp.task('integrationTests', function() {
 Options
 -------
 
-#### jasmineVersion
-Type: `string` <br />
-Default: '2.0'
-
-Specifies the version of Jasmine you want to run. Possible options are in the `vendor/` folder. Just specify what `2.x` minor release you want.
-
 #### integration
 Type: `boolean` <br />
 Default: false
@@ -134,6 +128,20 @@ globs (e.g. `"**/*.js"`) or fully-qualified URLs (e.g.
 
 This option accepts either a single string or an array of strings (e.g.
 `["test/*.js", "http://my.cdn.com/underscore.js"]`).
+
+#### jasmineVersion (integration tests only)
+Type: `string` <br />
+Default: '2.0'
+
+**Only use in combination with `integration: true`**
+
+Specifies the version of Jasmine you want to run. Possible options are in the `vendor/` folder. Just specify what `2.x` minor release you want.
+
+#### random (unit tests only)
+Type: 'boolean'<br />
+Default: false
+
+Allows you to run the unit tests in a semi-random order. The random seed will be printed out after the tests have completed to allow for easier debugging.
 
 Technologies Used
 -----------------

--- a/example/gulpfile.js
+++ b/example/gulpfile.js
@@ -11,6 +11,12 @@ gulp.task('unit', function() {
     return gulp.src('specs/unit/**.js').pipe(jasmine());
 });
 
+gulp.task('unit-random', function() {
+  return gulp.src('specs/unit/**.js').pipe(jasmine({
+    random: true
+  }));
+});
+
 // Unit test and keep the specRunner
 gulp.task('test-unit-path', function() {
   return gulp.src('specs/unit/**.js')

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ var _ = require('lodash'),
     handlebar = require('handlebars'),
     Jasmine = require('jasmine'),
     path = require('path'),
-    requireUncached = require('require-uncached'),
     through = require('through2');
 
 /*

--- a/index.js
+++ b/index.js
@@ -261,6 +261,10 @@ module.exports = function (options) {
           spec_files: filePaths
         });
 
+        if (_.has(gulpOptions, 'seed')) {
+          jasmine.seed(gulpOptions.seed);
+        }
+
         jasmine.onComplete(function(passed) {
           callback(null);
         });

--- a/index.js
+++ b/index.js
@@ -258,7 +258,7 @@ module.exports = function (options) {
         jasmine.addReporter(new terminalReporter(_.defaults(gulpOptions, {showColors: true})));
 
         jasmine.loadConfig({
-          random: true,
+          random: _.get(gulpOptions, 'random', false),
           spec_files: filePaths
         });
 

--- a/lib/terminal-reporter.js
+++ b/lib/terminal-reporter.js
@@ -30,7 +30,7 @@ exports.TerminalReporter = function(options) {
     timer.start();
   };
 
-  this.jasmineDone = function() {
+  this.jasmineDone = function(result) {
     printNewline();
     for (var i = 0; i < failedSpecs.length; i++) {
       if(!i) {
@@ -65,6 +65,11 @@ exports.TerminalReporter = function(options) {
 
     var seconds = timer.elapsed() / 1000;
     print('Finished in ' + seconds + ' ' + plural('second', seconds));
+
+    if (result && result.order && result.order.random) {
+      print('Randomized with seed ' + result.order.seed);
+      printNewline();
+    }
 
     done(failureCount === 0);
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-jasmine-phantom",
-  "version": "3.0.0-rc1",
+  "version": "3.0.0",
   "description": "Jasmine 2.0 suite runner, optionally with PhantomJS",
   "license": "MIT",
   "repository": "dflynn15/gulp-jasmine-phantom",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-jasmine-phantom",
-  "version": "3.0.0-beta1",
+  "version": "3.0.0-rc1",
   "description": "Jasmine 2.0 suite runner, optionally with PhantomJS",
   "license": "MIT",
   "repository": "dflynn15/gulp-jasmine-phantom",

--- a/package.json
+++ b/package.json
@@ -22,18 +22,18 @@
     "spec"
   ],
   "dependencies": {
+    "glob": "^4.0.6",
     "gulp-util": "^3.0.0",
-    "minijasminenode2": "dflynn15/minijasminenode",
-    "through2": "^0.6.1",
     "handlebars": "^2.0.0",
+    "jasmine": "dflynn15/jasmine-npm",
+    "lodash": "^4.3.0",
     "require-uncached": "^1.0.2",
-    "glob": "^4.0.6"
+    "through2": "^0.6.1"
   },
   "devDependencies": {
     "JSON": "^1.0.0",
     "gulp": "^3.8.7",
     "gulp-jasmine": "^1.0.1",
-    "jasmine": "^2.0.1",
     "jasmine-fixture": "^1.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-jasmine-phantom",
-  "version": "2.1.2",
+  "version": "3.0.0-beta1",
   "description": "Jasmine 2.0 suite runner, optionally with PhantomJS",
   "license": "MIT",
   "repository": "dflynn15/gulp-jasmine-phantom",
@@ -27,7 +27,6 @@
     "handlebars": "^2.0.0",
     "jasmine": "dflynn15/jasmine-npm",
     "lodash": "^4.3.0",
-    "require-uncached": "^1.0.2",
     "through2": "^0.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR is the bump up to `v3.0`. Here is the reasoning behind the changes.

*Breaking changes*
- No longer depend on `minijasminenode` as it is no longer actively maintained and does not stay in step with new Jasmine versions.
- Allows the plugin to use `jasmine-npm` which will be an explicit reference to Jasmine's core and maintained by Jasmine core team.

*Feature additions*
- Add the ability to run tests in a semi-random order
- Provide the random seed to reproduce a semi-random run of the tests

*Dependency additions*
- Adds lodash as a convenience for accessing attributes and for future cleanup that will utilize `map`, etc. that are ES2015 features not supported in Node `0.12`