### PR TITLE
Fix path to phantomjs executable and file system paths on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var _ = require('lodash'),
  * specHtml: string path to the tmp specRunner.html to be written out to
  * specRunner: string path to the specRunner JS file needed in the specRunner.html
  **/
-var phantomExecutable = process.platform === 'win32' ? 'phantomjs.cmd' : 'phantomjs',
+var phantomExecutable = 'phantomjs',
     gulpOptions = {},
     jasmineCss, jasmineJs,
     vendorJs = [],
@@ -94,7 +94,7 @@ function execPhantom(phantom, childArguments, onComplete) {
 
 /**
   * Executes Phantom with the specified arguments
-  * 
+  *
   * childArguments: Array of options to pass Phantom
   * [jasmine-runner.js, specRunner.html]
   **/
@@ -140,15 +140,23 @@ function compileRunner(options) {
         }
       });
     }
+    var fixupPath = function(path) {
+      if (path.match(/^http/)) {
+        return path;
+      }
+
+      return "file:///" + path.replace(/\\/g, '/');
+    }
+
     // Create the compile version of the specRunner from Handlebars
     var specData = handlebar.compile(data),
-        specCompiled = specData({
-          files: filePaths,
-          jasmineCss: jasmineCss,
-          jasmineJs: jasmineJs,
-          vendorJs: vendorJs,
-          specRunner: specRunner
-        });
+      specCompiled = specData({
+        files: filePaths.map(fixupPath),
+        jasmineCss: fixupPath(jasmineCss),
+        jasmineJs: jasmineJs.map(fixupPath),
+        vendorJs: vendorJs.map(fixupPath),
+        specRunner: fixupPath(specRunner)
+      });
 
     if(gulpOptions.keepRunner !== undefined && typeof gulpOptions.keepRunner === 'string') {
       specHtml = path.join(path.resolve(gulpOptions.keepRunner), '/specRunner.html');

--- a/index.js
+++ b/index.js
@@ -107,6 +107,20 @@ function runPhantom(childArguments, onComplete) {
   }
 }
 
+/**
+ * Converts a file path into a form able to be loaded by phantom. An absolute path (e.g. c:\dir\file.js) will be converted to
+ * a file URL (e.g., file:///c:/dir/file.js)
+ *
+ * path: a file path to convert
+ */
+function fixupPath(path) {
+  if (path.match(/^http/)) {
+    return path;
+  }
+
+  return "file:///" + path.replace(/\\/g, '/');
+}
+
 /*
  * Reads in the handlebar template and creates a data HTML object in memory to create
  *
@@ -139,13 +153,6 @@ function compileRunner(options) {
           });
         }
       });
-    }
-    var fixupPath = function(path) {
-      if (path.match(/^http/)) {
-        return path;
-      }
-
-      return "file:///" + path.replace(/\\/g, '/');
     }
 
     // Create the compile version of the specRunner from Handlebars

--- a/lib/jasmine-runner.js
+++ b/lib/jasmine-runner.js
@@ -29,7 +29,7 @@ page.onConsoleMessage = function(msg) {
     }
 };
 
-page.open(system.args[1], function(status) {
+page.open("file:///" + system.args[1], function(status) {
     if (status !== "success") {
       console.log("Couldn't load the page");
       phantom.exit(1);


### PR DESCRIPTION
Resolves #53 

This combines a fix from @Nysosis (https://github.com/dflynn15/gulp-jasmine-phantom/issues/53#issuecomment-200033552) along with fixing the name to run the phantomjs executable
