### PR TITLE
Runner option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ integration tests.
 Type: `string | array` <br />
 Default: null
 
+#### runner
+Type: `string` <br />
+Default: '/lib/jasmine-runner.js'
+
+Allows you to specify the javascript runner that jasmine uses when running tests.
+
 **Only use in combination with `integration: true`**
 
 A list of vendor scripts to import into the HTML runner, either as file

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ function execPhantom(phantom, childArguments, onComplete) {
 
 /**
   * Executes Phantom with the specified arguments
-  * 
+  *
   * childArguments: Array of options to pass Phantom
   * [jasmine-runner.js, specRunner.html]
   **/
@@ -159,9 +159,9 @@ function compileRunner(options) {
         throw error;
       }
 
-      if(gulpOptions.integration) {
+      if (gulpOptions.integration) {
         var childArgs = [
-          path.join(__dirname, '/lib/jasmine-runner.js'),
+          options.runner,
           specHtml,
           JSON.stringify(gulpOptions)
         ];
@@ -196,10 +196,11 @@ module.exports = function (options) {
       }, function (callback) {
         gutil.log('Running Jasmine with PhantomJS');
         try {
-          if(gulpOptions.specHtml) {
+          var runner = gulpOptions.runner || path.join(__dirname, '/lib/jasmine-runner.js');
+          if (gulpOptions.specHtml) {
             runPhantom(
               [
-                path.join(__dirname, '/lib/jasmine-runner.js'),
+                runner,
                 path.resolve(gulpOptions.specHtml),
                 JSON.stringify(gulpOptions)
               ], function(success) {
@@ -210,7 +211,8 @@ module.exports = function (options) {
               files: filePaths,
               onComplete: function(success) {
                 callback(success);
-              }
+              },
+              runner: runner
             });
           }
         } catch(error) {


### PR DESCRIPTION
Resoves #65

This option allows the caller to override the default jasmine-runner.js. My use case is to allow me to use the junit-reporter from https://github.com/larrymyers/jasmine-reporters. To use the junit-reporter in phantomjs, it is necessary to make significant changes to the runner script:

> It is strongly recommended to use the provided script to run your test suite using PhantomJS. If you want to use your own PhantomJS runner, you will need to inject a __phantom_writeFile method, and also take care to correctly determine when all results have been reported.
