### PR TITLE
:bug: fix: Fixes non-global Phantom use

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,21 @@ A gulp plugin that runs Jasmine tests with either PhantomJS or minijasminenode2.
 Dependencies
 ------------
 
-This module uses `execSync` which is not available in any version of Node under `0.12.x`.
-If you have any specific concerns about upgrading versions of Node or reasons not use
-`execSync` feel free to open an issue!
 
 Before you install `gulp-jasmine-phantom` please ensure that you have PhantomJS
 installed on your machine. The plugin assumes that the `phantomjs` binary is
 available in the PATH and executable from the command line.
 
-If not, ensure you at least have `phantomjs` as an npm dependency. The module
+If not, ensure you at least have `phantomjs-prebuilt` (or `phantomjs` which has been deprecated) as an npm dependency. The module
 checks in `./node_modules/phantomjs` for an executable if you do not have it
 installed globally.
 
 **If you do not have `phantomjs` installed please install following
-[these directions.](http://phantomjs.org/download.html)
+[these directions.](http://phantomjs.org/download.html)**
+
+This module uses `execSync` which is not available in any version of Node under `0.12.x`.
+If you have any specific concerns about upgrading versions of Node or reasons not use
+`execSync` feel free to open an issue!
 
 Install
 -----

--- a/index.js
+++ b/index.js
@@ -30,10 +30,12 @@ var phantomExecutable = getExecuteablePath(),
  * Taken straight from
  * https://github.com/Medium/phantomjs/blob/master/install.js#L71-L73
  */
-function checkForExecutable() {
-  return platform.process === 'win32' ?
-        path.join(process.cwd(),'node_modules', '.bin', 'phantomjs.exe') :
-        path.join(process.cwd(),'node_modules', '.bin', 'phantomjs')
+function getExecuteablePath() {
+  if (hasGlobalPhantom()) {
+    return process.platform === 'win32' ? 'phantomjs.cmd' : 'phantomjs';
+  }
+
+  return require('phantomjs').path;
 }
 
 function configJasmine(version) {

--- a/index.js
+++ b/index.js
@@ -19,13 +19,22 @@ var _ = require('lodash'),
  * specHtml: string path to the tmp specRunner.html to be written out to
  * specRunner: string path to the specRunner JS file needed in the specRunner.html
  **/
-var phantomExecutable = 'phantomjs',
+var phantomExecutable = getExecuteablePath(),
     gulpOptions = {},
     jasmineCss, jasmineJs,
     vendorJs = [],
     specHtml = path.join(__dirname, '/lib/specRunner.html'),
     specRunner = path.join(__dirname, '/lib/specRunner.js');
 
+/*
+ * Taken straight from
+ * https://github.com/Medium/phantomjs/blob/master/install.js#L71-L73
+ */
+function checkForExecutable() {
+  return platform.process === 'win32' ?
+        path.join(process.cwd(),'node_modules', '.bin', 'phantomjs.exe') :
+        path.join(process.cwd(),'node_modules', '.bin', 'phantomjs')
+}
 
 function configJasmine(version) {
   version = version || '2.0';
@@ -99,12 +108,11 @@ function execPhantom(phantom, childArguments, onComplete) {
   * [jasmine-runner.js, specRunner.html]
   **/
 function runPhantom(childArguments, onComplete) {
-  if(hasGlobalPhantom()) {
-    execPhantom(phantomExecutable, childArguments, onComplete);
-  } else {
-    gutil.log(gutil.colors.yellow('gulp-jasmine-phantom: Global Phantom undefined, trying to execute from node_modules/phantomjs'));
-    execPhantom(process.cwd() + '/node_modules/.bin/' + phantomExecutable, childArguments, onComplete);
+  if(!hasGlobalPhantom()) {
+    gutil.log(gutil.colors.yellow('gulp-jasmine-phantom: Phantom was not found globally, trying to execute from node_modules/.bin/'));
   }
+
+  execPhantom(phantomExecutable, childArguments, onComplete);
 }
 
 /**


### PR DESCRIPTION
This should fix the Windows specific path issues that @mnr1 was seeing after #66 was merged in. Also, this is the alternative to #70 that does not require us to explicitly download and install `phantomjs` during `npm install` but opts to allow user configuration. [Explanation here.](https://github.com/dflynn15/gulp-jasmine-phantom/pull/70#issuecomment-228464052)

@gwynjudd and @mnr1 would you mind double checking to ensure this does not break either of your environments? Thanks!
