### PR TITLE
Pass vendor files as helpers to node-jasmine.

### DIFF
--- a/index.js
+++ b/index.js
@@ -275,6 +275,7 @@ module.exports = function (options) {
 
         jasmine.loadConfig({
           random: _.get(gulpOptions, 'random', false),
+          helpers: _.get(gulpOptions, 'vendor', undefined),
           spec_files: filePaths
         });
 


### PR DESCRIPTION
We came across an issue where we needed to pass vendor files in above specfiles for node-jasmine. This change allows the option to be passed through.

---

For details on helpers, see:
http://jasmine.github.io/2.4/node.html#section-12

See also, about jasmine.loadConfig:
http://jasmine.github.io/2.4/node.html#section-Load_configuration_from_a_file_or_from_an_object.
