### PR TITLE
feature/optional-exit-on-fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ Prints out a longer stack trace for errors.
 Type: `boolean` <br />
 Default: false
 
-**Currently built with integration mode only** <br />
 Exits Gulp with an status of 1 that will halt any further Gulp tasks.
 
 #### specHtml

--- a/index.js
+++ b/index.js
@@ -283,7 +283,11 @@ module.exports = function (options) {
         }
 
         jasmine.onComplete(function(passed) {
-          callback(null);
+          if(!passed && gulpOptions.abortOnFail) {
+            callback(new gutil.PluginError('gulp-jasmine-phantom'));
+          }else{
+            callback(null);
+          }
         });
 
         jasmine.execute();

--- a/index.js
+++ b/index.js
@@ -284,7 +284,7 @@ module.exports = function (options) {
 
         jasmine.onComplete(function(passed) {
           if(!passed && gulpOptions.abortOnFail) {
-            callback(new gutil.PluginError('gulp-jasmine-phantom'));
+            callback(new gutil.PluginError('gulp-jasmine-phantom', 'not all specs passed'));
           }else{
             callback(null);
           }


### PR DESCRIPTION
I needed this to work for my circleci build process. I don't use integration switch to test nodejs modules/classes.

Might sound strange, but currently the build is failing to my delight :)

#23 (explains the problem well)
#25 (introduces a solution which i piggyback on)