### PR TITLE
Fix fs.unlink() callback bug for nodejs v10

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function configJasmine(version) {
   * Removes the specRunner.html file
   **/
 function cleanup(path) {
-  fs.unlink(path);
+  fs.unlinkSync(path);
 }
 
 function hasGlobalPhantom() {


### PR DESCRIPTION
This is the change that worked for me. See #79 for more info on the problem.